### PR TITLE
Update base docker tag to maven:3.9.8-amazoncorretto-11-al2023

### DIFF
--- a/for-ci-build-image/build-container.pkr.hcl
+++ b/for-ci-build-image/build-container.pkr.hcl
@@ -41,7 +41,7 @@ build {
   }
 
   provisioner "shell" {
-    inline = ["yum install -y git awscli gnupg jq xmlstarlet", "cd /root", "mvn install -f pom.xml", "mvn dependency:go-offline -f deps-pom.xml", "mkdir -p src/main/java", "mvn clean verify -f deps-pom.xml", "rm -rf target", "rm -rf src", "rm -f *.xml", "mv -f .m2/repository local_repo", "mkdir /maven", "rm -rf /etc/localtime", "ln -s /usr/share/zoneinfo/Australia/Sydney /etc/localtime"]
+    inline = ["yum install -y git awscli gnupg jq", "cd /root", "mvn install -f pom.xml", "mvn dependency:go-offline -f deps-pom.xml", "mkdir -p src/main/java", "mvn clean verify -f deps-pom.xml", "rm -rf target", "rm -rf src", "rm -f *.xml", "mv -f .m2/repository local_repo", "mkdir /maven", "rm -rf /etc/localtime", "ln -s /usr/share/zoneinfo/Australia/Sydney /etc/localtime"]
   }
 
   provisioner "shell" {

--- a/for-ci-build-image/build-container.pkr.hcl
+++ b/for-ci-build-image/build-container.pkr.hcl
@@ -19,7 +19,7 @@ variable "dockerhub_user" {
 
 source "docker" "image" {
   commit = "true"
-  image  = "maven:3.6.3-amazoncorretto-11"
+  image  = "maven:3.9.8-amazoncorretto-11-al2023"
 }
 
 build {
@@ -60,11 +60,11 @@ build {
       repository = "zepben/pipeline-java"
       tags       = ["latest"]
     }
-    post-processor "docker-push" {
-      name           = "docker.push"
-      login          = true
-      login_password = "${var.dockerhub_pw}"
-      login_username = "${var.dockerhub_user}"
-    }
+    # post-processor "docker-push" {
+    #   name           = "docker.push"
+    #   login          = true
+    #   login_password = "${var.dockerhub_pw}"
+    #   login_username = "${var.dockerhub_user}"
+    # }
   }
 }

--- a/for-ci-build-image/build-container.pkr.hcl
+++ b/for-ci-build-image/build-container.pkr.hcl
@@ -60,11 +60,11 @@ build {
       repository = "zepben/pipeline-java"
       tags       = ["latest"]
     }
-    # post-processor "docker-push" {
-    #   name           = "docker.push"
-    #   login          = true
-    #   login_password = "${var.dockerhub_pw}"
-    #   login_username = "${var.dockerhub_user}"
-    # }
+    post-processor "docker-push" {
+      name           = "docker.push"
+      login          = true
+      login_password = "${var.dockerhub_pw}"
+      login_username = "${var.dockerhub_user}"
+    }
   }
 }

--- a/for-ci-build-image/build-container.pkr.hcl
+++ b/for-ci-build-image/build-container.pkr.hcl
@@ -41,7 +41,7 @@ build {
   }
 
   provisioner "shell" {
-    inline = ["yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm", "yum install -y git awscli gnupg jq xmlstarlet", "cd /root", "mvn install -f pom.xml", "mvn dependency:go-offline -f deps-pom.xml", "mkdir -p src/main/java", "mvn clean verify -f deps-pom.xml", "rm -rf target", "rm -rf src", "rm -f *.xml", "mv -f .m2/repository local_repo", "mkdir /maven", "rm -rf /etc/localtime", "ln -s /usr/share/zoneinfo/Australia/Sydney /etc/localtime"]
+    inline = ["yum install -y git awscli gnupg jq xmlstarlet", "cd /root", "mvn install -f pom.xml", "mvn dependency:go-offline -f deps-pom.xml", "mkdir -p src/main/java", "mvn clean verify -f deps-pom.xml", "rm -rf target", "rm -rf src", "rm -f *.xml", "mv -f .m2/repository local_repo", "mkdir /maven", "rm -rf /etc/localtime", "ln -s /usr/share/zoneinfo/Australia/Sydney /etc/localtime"]
   }
 
   provisioner "file" {

--- a/for-ci-build-image/build-container.pkr.hcl
+++ b/for-ci-build-image/build-container.pkr.hcl
@@ -42,7 +42,7 @@ build {
 
   provisioner "shell" {
     inline = [
-      "yum -y install gcc libxml2 libxml2-devel libxslt-devel git awscli gnupg jq",
+      "yum -y install gcc wget libxml2 libxml2-devel libxslt-devel git awscli gnupg jq",
       "cd /tmp",
       "wget https://sourceforge.net/projects/xmlstar/files/xmlstarlet/1.6.1/xmlstarlet-1.6.1.tar.gz",
       "tar -xzvf xmlstarlet-1.6.1.tar.gz",

--- a/for-ci-build-image/build-container.pkr.hcl
+++ b/for-ci-build-image/build-container.pkr.hcl
@@ -44,6 +44,20 @@ build {
     inline = ["yum install -y git awscli gnupg jq xmlstarlet", "cd /root", "mvn install -f pom.xml", "mvn dependency:go-offline -f deps-pom.xml", "mkdir -p src/main/java", "mvn clean verify -f deps-pom.xml", "rm -rf target", "rm -rf src", "rm -f *.xml", "mv -f .m2/repository local_repo", "mkdir /maven", "rm -rf /etc/localtime", "ln -s /usr/share/zoneinfo/Australia/Sydney /etc/localtime"]
   }
 
+  provisioner "shell" {
+    inline = [
+      "cd /tmp",
+      "sudo yum -y install gcc libxml2 libxml2-devel libxslt-devel",
+      "wget https://sourceforge.net/projects/xmlstar/files/xmlstarlet/1.6.1/xmlstarlet-1.6.1.tar.gz",
+      "tar -xzvf xmlstarlet-1.6.1.tar.gz",
+      "cd xmlstarlet-1.6.1",
+      "./configure",
+      "export C_INCLUDE_PATH=/usr/include/libxml2",
+      "make",
+      "make install"
+    ]
+  }
+
   provisioner "file" {
     destination = "/root/.m2/settings.xml"
     source      = "maven-settings.xml"

--- a/for-ci-build-image/build-container.pkr.hcl
+++ b/for-ci-build-image/build-container.pkr.hcl
@@ -41,13 +41,9 @@ build {
   }
 
   provisioner "shell" {
-    inline = ["yum install -y git awscli gnupg jq", "cd /root", "mvn install -f pom.xml", "mvn dependency:go-offline -f deps-pom.xml", "mkdir -p src/main/java", "mvn clean verify -f deps-pom.xml", "rm -rf target", "rm -rf src", "rm -f *.xml", "mv -f .m2/repository local_repo", "mkdir /maven", "rm -rf /etc/localtime", "ln -s /usr/share/zoneinfo/Australia/Sydney /etc/localtime"]
-  }
-
-  provisioner "shell" {
     inline = [
+      "sudo yum -y install gcc libxml2 libxml2-devel libxslt-devel git awscli gnupg jq",
       "cd /tmp",
-      "sudo yum -y install gcc libxml2 libxml2-devel libxslt-devel",
       "wget https://sourceforge.net/projects/xmlstar/files/xmlstarlet/1.6.1/xmlstarlet-1.6.1.tar.gz",
       "tar -xzvf xmlstarlet-1.6.1.tar.gz",
       "cd xmlstarlet-1.6.1",
@@ -56,6 +52,10 @@ build {
       "make",
       "make install"
     ]
+  }
+
+  provisioner "shell" {
+    inline = ["cd /root", "mvn install -f pom.xml", "mvn dependency:go-offline -f deps-pom.xml", "mkdir -p src/main/java", "mvn clean verify -f deps-pom.xml", "rm -rf target", "rm -rf src", "rm -f *.xml", "mv -f .m2/repository local_repo", "mkdir /maven", "rm -rf /etc/localtime", "ln -s /usr/share/zoneinfo/Australia/Sydney /etc/localtime"]
   }
 
   provisioner "file" {

--- a/for-ci-build-image/build-container.pkr.hcl
+++ b/for-ci-build-image/build-container.pkr.hcl
@@ -42,7 +42,7 @@ build {
 
   provisioner "shell" {
     inline = [
-      "sudo yum -y install gcc libxml2 libxml2-devel libxslt-devel git awscli gnupg jq",
+      "yum -y install gcc libxml2 libxml2-devel libxslt-devel git awscli gnupg jq",
       "cd /tmp",
       "wget https://sourceforge.net/projects/xmlstar/files/xmlstarlet/1.6.1/xmlstarlet-1.6.1.tar.gz",
       "tar -xzvf xmlstarlet-1.6.1.tar.gz",


### PR DESCRIPTION
# Description

Full context here https://zepben.slack.com/archives/GAHA1BEGL/p1720763255524979

We updated the `actions/checkout@v4` which depends on a newer version of node, which in turn depends on a newer version of glibc. 

It seems the image we were using was basically EOL since it was build off Amazon Linux 2. The newer images are all tagged `-al2023` which stands for Amazon Linux 2023 which has all the newer things since its actually kept up to date.

# Associated tasks

N/A

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [ ] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have rebased onto the target branch (usually main).
      
### Documentation
- [ ] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.

Please leave a summary of the breaking changes here. This is useful for the reviewer, but also is useful for communication to the team when merged (e.g. you could copy and paste the summary into slack).

# Screenshots

Remove this section if the change cannot be shown through screenshots. Frontend changes should mostly include this section.
Screenshots can be copy-pasted into Github textboxes and a link will automatically be generated.
Remove this text if you choose to use this section.

| Before | After |
| --- | --- |
| ![image](image-link-here) | ![image](image-link-here) |
