### PR TITLE
[DEV-1466] Add AWS SDK Bom to super pom

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## [0.36.6]
+
+### Enhancements
+- Change from using `s3` SDK dependecy directly to use AWS SDK BOM
+
 ## [0.36.5]
 
 ### New Features

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,9 @@
         <!-- azure sdk -->
         <azure.bom.version>1.0.5</azure.bom.version>
 
+        <!-- aws sdk -->
+        <aws.sdk.version>2.27.21</aws.sdk.version>
+
         <dokka.version>1.9.20</dokka.version>
 
         <apache.lucene.version>9.9.2</apache.lucene.version>
@@ -533,8 +536,10 @@
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
-                <artifactId>s3</artifactId>
-                <version>2.27.11</version>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.36.5</version>
+    <version>0.36.6</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
# Description

In DEV-1444, I am adding ECS support to the hosting-capacity-utils container runtime which requires the AWS ECS dependency. In doing so, I realized that @clydeu had previously added s3 as a dependency. I noticed that the dependency version was different to the one I am adding. Upon further research I realized that AWS SDK packages all track with the same version and therefore we were better off using the BOM here.

# Associated tasks

- DEV-1444 (haven't started yet)

# Test Steps

Tested on @clydeu's PR already to sanity check that what I did worked

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ N/A
- [ ]  ~I have commented my code in any hard-to-understand or hacky areas.~ N/A
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~ N/A

# Breaking Changes
- [ ] ~I have considered if this is a breaking change and will communicate it with other team members if so.~ N/A
