### PR TITLE
[OPS-264] Cleaning the single quote around a list parameter

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -66,7 +66,7 @@ jobs:
           # Handle the resulting container labels if provided
           if [ "z${{ github.event.client_payload.labels }}" != "z" ]; then
             # the labels come in as "label1 label2" but we need to provide them as
-            # '["label1", "label2"]'
+            # ["label1", "label2"]
             # So we replace the original values with quoted ones and then wrap in braces
 
             # Split the passed values into an array
@@ -74,7 +74,7 @@ jobs:
             # Print every array entry encased by double quotes
             tags=$(printf "\"%s\"," "${array[@]}")
             # Construct the list parameter for the container tags
-            IMAGE_TAGS="-var tags='[$tags]'"
+            IMAGE_TAGS="-var tags=[$tags]"
           fi
 
           cd for-ci-build-image


### PR DESCRIPTION
# Description

The bash parameter passing is not friendly with packer and vice versa, so removing single quotes from the packer *list* parameter.

This was tested in a test repo: https://github.com/zepben/mvn-lib-ci-test/actions/runs/11472726151/job/31925756881

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [ ] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Not a breaking change.
