### PR TITLE
[DEV-21800] Update Azure BOM and Vertx to fix EntraID Workload Identity authentication loop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 ## [0.37.0]
+
+### Enhancements
 - Update `azure-bom` property to `1.2.30` to fix workload identity authentication loop
 - Update `vertx` to `4.5.11` to fix compatiblity issue with `azure-bom` transitive `netty` dependency
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,11 @@
+## [0.37.0]
+- Update `azure-bom` property to `1.2.30` to fix workload identity authentication loop
+- Update `vertx` to `4.5.11` to fix compatiblity issue with `azure-bom` transitive `netty` dependency
+
 ## [0.36.6]
 
 ### Enhancements
-- Change from using `s3` SDK dependecy directly to use AWS SDK BOM
+- Change from using `s3` SDK dependency directly to use AWS SDK BOM
 
 ## [0.36.5]
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.36.7</version>
+    <version>0.37.0</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -73,7 +73,7 @@
 
         <autovalue.version>1.7</autovalue.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <vertx.version>4.4.6</vertx.version>
+        <vertx.version>4.5.11</vertx.version>
 
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
         <mockito.version>3.12.4</mockito.version>
@@ -108,7 +108,7 @@
         <ktor.version>2.1.0</ktor.version>
 
         <!-- azure sdk -->
-        <azure.bom.version>1.0.5</azure.bom.version>
+        <azure.bom.version>1.2.30</azure.bom.version>
 
         <!-- aws sdk -->
         <aws.sdk.version>2.27.21</aws.sdk.version>


### PR DESCRIPTION
# Description

During the deployment of Endeavour, the bootup sequence for EWB was taking a long time to download the network database from Azure Blob. With logging we could see that once the library acquired the Workload Identity token, it would do a single 4MB chunked download and then would wait 30 seconds before fetching another token and retrying to process.

We traced this to a bug in the Azure library that was fixed back in ~2022. [See here](https://github.com/Azure/azure-sdk-for-java/issues/30651). As a result, we updated from the ancient version of the BOM we were using to the latest.

In doing so, we ran into a compatibility issue between Vert.x and AzureBOM. Both libraries (and in fact, also the AWS library) have a transitive dependency on Netty. To fix this, we upgraded to the latest Vert.x release for the version 4 series.

# Test Steps

Was tested manually by inserting the dependencies in EWB explicitly and then booting it up from a network database in a storage account.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ]~ I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [ ] ~I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.
