### PR TITLE
[OPS-323] Parse push_image properly, replace with 'true' if not provided

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -3,11 +3,6 @@ name: Build CI Container
 on:
   repository_dispatch:
     types: [build-container]
-    inputs:
-      push_image:
-        description: If the image should be pushed to the registry
-        type: boolean
-        default: true
   workflow_dispatch:
     inputs:
       commit:
@@ -232,9 +227,11 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v6
+        env:  
+          push_image: ${{ contains(null, inputs.push_image) && toJson('true') || inputs.push_image }}
         with:
           context: "./for-ci-build-image"
-          push: ${{ inputs.push_image }}
+          push: ${{ env.push_image }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
When launched via `repository_dispatch`, the input `push_image` is not defined (null) and hence fails the docker image push.

This change creates and uses a new environment var with the same value as `push_image` if that is provided, or `true` otherwise.

# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

Not a breaking change.