### PR TITLE
[OPS-367] migrate ossrh to central

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -16,6 +16,13 @@ jobs:
       NEXUS_MAVEN_RELEASE: ${{ secrets.NEXUS_MAVEN_RELEASE }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Work around git permission issue
+        run: |
+          dname=$(echo ${{github.repository}} | cut -d'/' -f2)
+          git config --global --add safe.directory /__w/$dname/$dname
+        shell: sh
+
       - name: Check version doesn't already exist
         run: |
           /scripts/release-checks.sh --java --maven pom.xml

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## [0.39.0]
+
+### Enhancements
+- Migrate OSSRH repository to Maven Central
+
 ## [0.38.0]
 
 ### Enhancements

--- a/for-ci-build-image/maven-settings.xml
+++ b/for-ci-build-image/maven-settings.xml
@@ -18,9 +18,9 @@
             </configuration>
         </server>
         <server>
-            <id>ossrh</id>
-            <username>${ossrh.server.username}</username>
-            <password>${ossrh.server.password}</password>
+            <id>maven-central</id>
+            <username>${maven-central.server.username}</username>
+            <password>${maven-central.server.password}</password>
         </server>
         <server>
             <id>${gpg.key}</id>
@@ -29,7 +29,7 @@
     </servers>
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>maven-central</id>
             <properties>
                 <gpg.keyname>${gpg.key}</gpg.keyname>
                 <gpg.executable>gpg</gpg.executable>
@@ -101,27 +101,10 @@
                 </pluginRepository>
             </pluginRepositories>
         </profile>
-        <profile>
-            <id>allow-snapshots</id>
-            <repositories>
-                <repository>
-                    <id>snapshots-repo</id>
-                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-                    <releases>
-                        <enabled>false</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                        <updatePolicy>always</updatePolicy>
-                    </snapshots>
-                </repository>
-            </repositories>
-        </profile>
     </profiles>
     <activeProfiles>
         <activeProfile>local-maven</activeProfile>
         <activeProfile>zepben-maven</activeProfile>
-        <activeProfile>ossrh</activeProfile>
-        <activeProfile>allow-snapshots</activeProfile>
+        <activeProfile>maven-central</activeProfile>
     </activeProfiles>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -1069,15 +1069,13 @@ See: https://central.sonatype.org/pages/apache-maven.html#gpg-signed-components 
 
                     <!-- Plugin for deploying to maven central -->
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
+                      <groupId>org.sonatype.central</groupId>
+                      <artifactId>central-publishing-maven-plugin</artifactId>
+                      <version>0.7.0</version>
+                      <extensions>true</extensions>
+                      <configuration>
+                        <publishingServerId>maven-central</publishingServerId>
+                      </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1013,8 +1013,6 @@
         <profile>
             <id>release</id>
             <build>
-                <!-- Sign artifacts with gpg. Requires gpg command to be available and creds configured in settings.xml
-See: https://central.sonatype.org/pages/apache-maven.html#gpg-signed-components -->
                 <plugins>
                     <plugin>
                         <groupId>org.jetbrains.dokka</groupId>
@@ -1044,6 +1042,8 @@ See: https://central.sonatype.org/pages/apache-maven.html#gpg-signed-components 
                         </configuration>
                     </plugin>
 
+                    <!-- Sign artifacts with gpg. Requires gpg command to be available and creds configured in settings.xml
+    See: https://central.sonatype.org/pages/apache-maven.html#gpg-signed-components -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.38.3</version>
+    <version>0.39.0</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Migrate to Maven Central off OSSRH

- Change the plugin to use for deploying to Maven Central.
- Change the ossrh profile name to `maven-central` for posterity
- Remove `allow-snapshots` profile as the new plugin supports snapshots deployments directly (to be tested properly).

Related PRs (to be merged *PRIOR* to this one):
- https://github.com/zepben/maven-deploy-central-action/pull/6
- https://github.com/zepben/.github/pull/73
- https://github.com/zepben/ci-utils/pull/30

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

This is a breaking change. To move to the Central we'll need to update our namespace and as a result the old method to push to the packages will not work and all the dependency chain will have to use this version of superpom to properly acquire the correct method of pushing to central. 