### PR TITLE
[OPS-406] Bump central-publishing-maven-plugin to 0.8.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## [0.39.4]
+
+### Enhancements
+- Bump `central-publishing-maven-plugin` to 0.8.0
+
 ## [0.39.3]
 
 ### Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -1071,7 +1071,7 @@
                     <plugin>
                       <groupId>org.sonatype.central</groupId>
                       <artifactId>central-publishing-maven-plugin</artifactId>
-                      <version>0.7.0</version>
+                      <version>0.8.0</version>
                       <extensions>true</extensions>
                       <configuration>
                         <publishingServerId>maven-central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.39.3</version>
+    <version>0.39.4</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
# Description

We need to rebuild the way we handle snapshots in maven, so this is a good opportunity to also bump the plugin for pushing the builds to Maven Central. It _might_ allows us using real snapshots if we wanted to.

# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

Related upstream PR: https://github.com/zepben/ci-utils/pull/34 (has to be merged first)

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

This specific change is not breaking, but it will rely on basic pipelines that break the way maven snapshots are handled.