### PR TITLE
[DEV-3745] Remove provided scope from ktor client deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -665,13 +665,11 @@
                 <groupId>io.ktor</groupId>
                 <artifactId>ktor-client-cio-jvm</artifactId>
                 <version>${ktor.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.ktor</groupId>
                 <artifactId>ktor-client-jvm</artifactId>
                 <version>${ktor.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.ktor</groupId>
@@ -682,7 +680,6 @@
                 <groupId>io.ktor</groupId>
                 <artifactId>ktor-client-content-negotiation-jvm</artifactId>
                 <version>${ktor.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.ktor</groupId>


### PR DESCRIPTION
# Description

Seems to be some copy-pasta error, the provided scope was copied over from the new Zepben commons repo. Having this scope means that EAS builds expect that we provide the ktor CIO et al. JARs separately in some other way, meaning that EAS fails to compile.

This PR removes the provided scope and thus changing it to the default compile scope

# Test Steps

Tested inline in EAS already

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [ ] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.
